### PR TITLE
fix for delete_field check

### DIFF
--- a/Manager/UploadFileManager.php
+++ b/Manager/UploadFileManager.php
@@ -47,7 +47,9 @@ class UploadFileManager extends \Symfony\Component\DependencyInjection\Container
                 $elem->move($this->container->get('kernel')->getRootDir() . '/../web'.$column->getUploadPath(), $new);
                 $item->{$setter}($new);
 
-            } elseif (isset($form['delete_'.$column->getName()])) {
+            } elseif (isset($form['delete_' . $column->getName()]) &&
+                ($form['delete_' . $column->getName()]->getData() === true)
+            ) {
                 $item->{$setter}(null);
             } elseif (isset($default_values[$column->getName()])) {
                 $item->{$setter}($default_values[$column->getName()]);


### PR DESCRIPTION
WIth old version of code, field nulled in all cases. Here little fix for this - checking value, not the exisiting
